### PR TITLE
create projectList script

### DIFF
--- a/projectList.sh
+++ b/projectList.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#*****************************************************************
+#*
+#* Copyright 2020 IBM Corporation
+#*
+#* Licensed under the Apache License, Version 2.0 (the "License");
+#* you may not use this file except in compliance with the License.
+#* You may obtain a copy of the License at
+
+#* http://www.apache.org/licenses/LICENSE-2.0
+#* Unless required by applicable law or agreed to in writing, software
+#* distributed under the License is distributed on an "AS IS" BASIS,
+#* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#* See the License for the specific language governing permissions and
+#* limitations under the License.
+#*
+#*****************************************************************
+# Defines the list of kAppNav projects for use by other scripts
+
+BUILD_PROJECTS='apis controller inv operator ui'
+ALL_PROJECTS=$BUILD_PROJECTS' README build samples kappnav-website'


### PR DESCRIPTION
Multiple scripts have a list of kAppNav projects and images.  Create a single definition for these for use by the scripts.